### PR TITLE
update to make sure directory is current so that after download of ov…

### DIFF
--- a/linux_goliad.sh
+++ b/linux_goliad.sh
@@ -121,6 +121,7 @@
             while read LINE; do  lynx -dump -listonly  "${LINE}" ; done < /tmp/sub1.txt >/tmp/sub2.txt
             cat /tmp/sub2.txt | grep ".ovpn" | awk -F ' ' '{print $2}'  > /tmp/sub3.txt
             while read LINE;do curl -O "${LINE}"; done</tmp/sub3.txt
+            cd -
 
        # I am checking for new mirrored addresses so i can then download the .ovpn files
        # These endpoints are updated every 24 hours, but there is no need to create a cronjob locally for this as it would take too many resources

--- a/macos_goliad.sh
+++ b/macos_goliad.sh
@@ -122,6 +122,7 @@
             while read LINE; do  lynx -dump -listonly  "${LINE}" ; done < /tmp/sub1.txt >/tmp/sub2.txt
             cat /tmp/sub2.txt | grep ".ovpn" | awk -F ' ' '{print $2}'  > /tmp/sub3.txt
             while read LINE;do curl -O "${LINE}"; done</tmp/sub3.txt
+            cd -
 
        # I am checking for new mirrored addresses so i can then download the .ovpn files
        # These endpoints are updated every 24 hours, but there is no need to create a cronjob locally for this as it would take too many resources


### PR DESCRIPTION
…pn files the directory is set to default directory for vpn connection


**BUG**

Whenever vpn files are downloaded selecting **option 0**, the directory after completing the download is set to `CONNECTIONS` which in turn after running **option 1** for connection vpn will try to look files into the directory `Goliad/CONNECTIONS/CONNECTIONS` and fails saying files not found.

This PR is a small fix for that.

![image](https://user-images.githubusercontent.com/61139563/136748822-8c6db133-db85-4238-8a6e-5a383ee9f07c.png)
)